### PR TITLE
:adhesive_bandage: Update resolveEndpoint function

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -87,8 +87,8 @@ func (c *jac) perform(method, endpoint string, data []byte, destination any) ([]
 // resolveEndpoint forms url by adding endpoint to base url.
 // It ignores possible errors
 func (c *jac) resolveEndpoint(endpoint string) string {
-	result, _ := url.JoinPath(c.BaseUrl, endpoint)
-	return result
+	link, _ := url.Parse(fmt.Sprintf("%s%s", c.BaseUrl, endpoint))
+	return link.String()
 }
 
 // do sends specified request to specified endpoint based on received method and data


### PR DESCRIPTION
# Problem

`resolveEndpoint` joined query parameters directly to the path parameters by encoding `?` to `%3F`, because of it services can't recognize query parameters from URL path.

# Solution

Use `url.QueryUnescape` function to decode all 3-byte encoded substrings to their original values, also errors are handled for functions.