### PR TITLE
Change requests performing flow

### DIFF
--- a/configer.go
+++ b/configer.go
@@ -21,8 +21,7 @@ type jacer struct {
 
 // JacConfig contains configurable data of a Jac
 type JacConfig struct {
-	URL string  `fig:"url,required"`
-	JWT *string `fig:"jwt"`
+	URL string `fig:"url,required"`
 }
 
 // NewJACer returns an instance of JACer structure that configures Jac
@@ -56,5 +55,5 @@ func (c *jacer) GetJacConfig(configKey *string) JacConfig {
 //     If nil, then default key is used
 func (c *jacer) ConfigureJac(configKey *string) Jac {
 	cfg := c.GetJacConfig(configKey)
-	return NewJac(cfg.URL, cfg.JWT)
+	return NewJac(cfg.URL)
 }

--- a/configer_test.go
+++ b/configer_test.go
@@ -1,9 +1,10 @@
 package jac
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"gitlab.com/distributed_lab/kit/kv"
-	"testing"
 )
 
 const (
@@ -16,10 +17,8 @@ func TestJacer_GetJacConfig(t *testing.T) {
 		myJacer := NewJACer(kv.NewViperFile(jacTestConfigKey1))
 		jacCfg := myJacer.GetJacConfig(nil)
 
-		expectJwt := "my-coolest-jwt"
 		assert.Equal(t, JacConfig{
 			URL: "http://localhost:8000",
-			JWT: &expectJwt,
 		}, jacCfg)
 	})
 
@@ -28,10 +27,8 @@ func TestJacer_GetJacConfig(t *testing.T) {
 		jacCfgKey := "my-connector-name"
 		jacCfg := myJacer.GetJacConfig(&jacCfgKey)
 
-		expectJwt := "my-worst-jwt"
 		assert.Equal(t, JacConfig{
 			URL: "http://localhost:8001",
-			JWT: &expectJwt,
 		}, jacCfg)
 	})
 

--- a/connector.go
+++ b/connector.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/google/jsonapi"
-	"gitlab.com/distributed_lab/logan/v3/errors"
 	"io"
 	"net/http"
 	"net/url"
+
+	"github.com/google/jsonapi"
+	"gitlab.com/distributed_lab/logan/v3/errors"
 )
 
 // jac is a structure that implements Jac interface
@@ -23,7 +24,8 @@ func NewJac(baseUrl string, jwt *string) Jac {
 	return &jac{baseUrl, jwt, http.DefaultClient}
 }
 
-func (c *jac) Get(endpoint string, destination any) ([]*jsonapi.ErrorObject, error) {
+// func (c *jac) Get(endpoint string, destination any) ([]*jsonapi.ErrorObject, error) {
+func (c *jac) Get(params RequestParams) ([]*jsonapi.ErrorObject, error) {
 	return c.perform(http.MethodGet, endpoint, nil, destination)
 }
 
@@ -66,13 +68,14 @@ func (c *jac) NotExists(endpoint string) (bool, error) {
 }
 
 // perform performs a request based on given parameters
-func (c *jac) perform(method, endpoint string, data []byte, destination any) ([]*jsonapi.ErrorObject, error) {
-	response, err := c.do(method, c.resolveEndpoint(endpoint), data)
+// func (c *jac) perform(method, endpoint string, data []byte, destination any) ([]*jsonapi.ErrorObject, error) {
+func (c *jac) perform(params RequestParams) ([]*jsonapi.ErrorObject, error) {
+	response, err := c.do(params)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to send request")
 	}
 
-	errsPayload, err := c.readResponseBody(response, destination)
+	errsPayload, err := c.readResponseBody(response, params.Destination)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}
@@ -92,7 +95,7 @@ func (c *jac) resolveEndpoint(endpoint string) string {
 }
 
 // do sends specified request to specified endpoint based on received method and data
-func (c *jac) do(method, endpoint string, data []byte) (*http.Response, error) {
+func (c *jac) do(params RequestParams) (*http.Response, error) {
 	request, err := http.NewRequest(method, endpoint, bytes.NewReader(data))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create a request")

--- a/connector.go
+++ b/connector.go
@@ -16,13 +16,12 @@ import (
 // jac is a structure that implements Jac interface
 type jac struct {
 	BaseUrl string
-	JWT     *string
 	client  *http.Client
 }
 
 // NewJac returns new jac instance that implements Jac interface
-func NewJac(baseUrl string, jwt *string) Jac {
-	return &jac{baseUrl, jwt, http.DefaultClient}
+func NewJac(baseUrl string) Jac {
+	return &jac{baseUrl, http.DefaultClient}
 }
 
 func (c *jac) Get(params RequestParams, destination any) ([]*jsonapi.ErrorObject, error) {
@@ -113,7 +112,6 @@ func (c *jac) do(params RequestParams) (*http.Response, error) {
 		return nil, errors.Wrap(err, "failed to create a request")
 	}
 
-	request = c.setAuthorization(request)
 	request = params.addRequestHeaders(request)
 	request = params.addRequestQuery(request)
 
@@ -155,15 +153,4 @@ func (c *jac) readResponseBody(response *http.Response, destination any) (
 
 	err = json.Unmarshal(raw, &destination)
 	return nil, err
-}
-
-// setAuthorization sets JWT to the Authorization header.
-// If no JWT token were provided, function simply returns unmodified request
-func (c *jac) setAuthorization(r *http.Request) *http.Request {
-	if c.JWT == nil {
-		return r
-	}
-
-	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", *c.JWT))
-	return r
 }

--- a/connector_test.go
+++ b/connector_test.go
@@ -3,14 +3,15 @@ package jac
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/assert"
 	"gitlab.com/distributed_lab/ape"
 	"gitlab.com/distributed_lab/ape/problems"
 	"gitlab.com/distributed_lab/kit/kv"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 // -- Test API --
@@ -103,7 +104,7 @@ func TestJacer_Get(t *testing.T) {
 
 	t.Run("get request", func(t *testing.T) {
 		var testResponse getTestResponse
-		_, err := testJac.Get(testUrlBase, &testResponse)
+		_, err := testJac.Get(RequestParams{Endpoint: testUrlBase}, &testResponse)
 		assert.Nil(t, err, "expected nil error when unmarshalling response")
 		assert.Equal(t, getTestResponse{Foo: "bar"}, testResponse)
 	})
@@ -126,13 +127,25 @@ func TestJacer_Post(t *testing.T) {
 
 	t.Run("post add request", func(t *testing.T) {
 		var testAddResponse postTestResponse
-		_, err = testJac.Post(fmt.Sprintf("%s/%s", testUrlBase, "add"), requestAsBytes, &testAddResponse)
+		_, err = testJac.Post(
+			RequestParams{
+				Endpoint: fmt.Sprintf("%s/%s", testUrlBase, "add"),
+				Body:     requestAsBytes,
+			},
+			&testAddResponse,
+		)
 		assert.Nil(t, err, "expected nil error when unmarshalling add response")
 		assert.Equal(t, testAddResponse, testAddExpectedResponse)
 	})
 	t.Run("post multiply request", func(t *testing.T) {
 		var testMultiplyResponse postTestResponse
-		_, err = testJac.Post(fmt.Sprintf("%s/%s", testUrlBase, "multiply"), requestAsBytes, &testMultiplyResponse)
+		_, err = testJac.Post(
+			RequestParams{
+				Endpoint: fmt.Sprintf("%s/%s", testUrlBase, "multiply"),
+				Body:     requestAsBytes,
+			},
+			&testMultiplyResponse,
+		)
 		assert.Nil(t, err, "expected nil error when unmarshalling multiply response")
 		assert.Equal(t, testMultiplyResponse, testMultiplyExpectedResponse)
 	})

--- a/connector_test.go
+++ b/connector_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gitlab.com/distributed_lab/ape"
 	"gitlab.com/distributed_lab/ape/problems"
-	"gitlab.com/distributed_lab/kit/kv"
 )
 
 // -- Test API --
@@ -82,15 +81,13 @@ func newTestRouter() chi.Router {
 
 const (
 	testUrlBase = "/integrations/some-logic"
-	testConfig  = "test-config-1.yaml"
 )
 
 var testRouter = newTestRouter()
 
 func getTestJac(server *httptest.Server) Jac {
 	var (
-		testJacCfg = NewJACer(kv.NewViperFile(testConfig)).GetJacConfig(nil)
-		testJac    = NewJac(server.URL, testJacCfg.JWT)
+		testJac = NewJac(server.URL)
 	)
 
 	return testJac

--- a/examples/custom_connector.go
+++ b/examples/custom_connector.go
@@ -2,6 +2,7 @@ package examples
 
 import (
 	"encoding/json"
+
 	"github.com/zspkg/jac"
 )
 
@@ -25,9 +26,9 @@ type FooCreateResponse struct {
 // NewFooServiceConnector is your custom connector to FooService where
 // you can define your own data transformations and operations and
 // then use jac.Jac's methods to easily send POST/GET/DELETE methods
-func NewFooServiceConnector(baseEndpoint string, jwt *string) *FooServiceConnector {
+func NewFooServiceConnector(baseEndpoint string) *FooServiceConnector {
 	return &FooServiceConnector{
-		jac.NewJac(baseEndpoint, jwt),
+		jac.NewJac(baseEndpoint),
 		"foo/create",
 	}
 }
@@ -46,7 +47,13 @@ func (c *FooServiceConnector) CreateFoo(foo Foo) (*FooCreateResponse, error) {
 
 	// sending POST request to our service via connector
 	// to create new Foo instance
-	apiErrs, err := c.Post(c.createFooEndpoint, rawFoo, &response)
+	apiErrs, err := c.Post(
+		jac.RequestParams{
+			Endpoint: c.createFooEndpoint,
+			Body:     rawFoo,
+		},
+		&response,
+	)
 	if err != nil {
 		// your custom error handling
 	}

--- a/main.go
+++ b/main.go
@@ -7,17 +7,17 @@ type Jac interface {
 	// Get sends GET request and reads response body into destination.
 	// Returns a slice of API error objects according to JSON API or
 	// error if some happened during the operation.
-	Get(params RequestParams) ([]*jsonapi.ErrorObject, error)
+	Get(params RequestParams, destination any) ([]*jsonapi.ErrorObject, error)
 	// Post sends POST request with provided data as a request body
 	// and reads response body if some data is expected to return.
 	// Returns a slice of API error objects according to JSON API or
 	// error if some happened during the operation.
-	Post(params RequestParams) ([]*jsonapi.ErrorObject, error)
+	Post(params RequestParams, destination any) ([]*jsonapi.ErrorObject, error)
 	// Patch sends PATCH request with provided data as a request body
 	// and reads response body if some data is expected to return.
 	// Returns a slice of API error objects according to JSON API or
 	// error if some happened during the operation.
-	Patch(params RequestParams) ([]*jsonapi.ErrorObject, error)
+	Patch(params RequestParams, destination any) ([]*jsonapi.ErrorObject, error)
 	// Delete sends DELETE request.
 	// Returns a slice of API error objects according to JSON API or
 	// error if some happened during the operation.

--- a/main.go
+++ b/main.go
@@ -7,29 +7,29 @@ type Jac interface {
 	// Get sends GET request and reads response body into destination.
 	// Returns a slice of API error objects according to JSON API or
 	// error if some happened during the operation.
-	Get(endpoint string, destination any) ([]*jsonapi.ErrorObject, error)
+	Get(params RequestParams) ([]*jsonapi.ErrorObject, error)
 	// Post sends POST request with provided data as a request body
 	// and reads response body if some data is expected to return.
 	// Returns a slice of API error objects according to JSON API or
 	// error if some happened during the operation.
-	Post(endpoint string, data []byte, destination any) ([]*jsonapi.ErrorObject, error)
+	Post(params RequestParams) ([]*jsonapi.ErrorObject, error)
 	// Patch sends PATCH request with provided data as a request body
 	// and reads response body if some data is expected to return.
 	// Returns a slice of API error objects according to JSON API or
 	// error if some happened during the operation.
-	Patch(endpoint string, data []byte, destination any) ([]*jsonapi.ErrorObject, error)
+	Patch(params RequestParams) ([]*jsonapi.ErrorObject, error)
 	// Delete sends DELETE request.
 	// Returns a slice of API error objects according to JSON API or
 	// error if some happened during the operation.
-	Delete(endpoint string) ([]*jsonapi.ErrorObject, error)
+	Delete(params RequestParams) ([]*jsonapi.ErrorObject, error)
 	// Exists checks if object exists by provided endpoint.
 	// Returns error if non-2xx status differs from 404 or
 	// something happened during the operation.
-	Exists(endpoint string) (bool, error)
+	Exists(params RequestParams) (bool, error)
 	// NotExists checks if object is not exist by provided endpoint.
 	// Returns error if non-2xx status differs from 404 or
 	// something happened during the operation.
-	NotExists(endpoint string) (bool, error)
+	NotExists(params RequestParams) (bool, error)
 }
 
 // JACer is the interface that connector configurator should implement

--- a/request_params.go
+++ b/request_params.go
@@ -1,0 +1,21 @@
+package jac
+
+import (
+	"time"
+)
+
+// RequestParams is a structure for performing different requests
+type RequestParams struct {
+	method      string
+	Endpoint    string
+	Body        []byte
+	Destination any
+	Query       map[string]string
+	Header      map[string]string
+	Timeout     time.Duration
+}
+
+func (rp RequestParams) addMethod(method string) RequestParams {
+	rp.method = method
+	return rp
+}

--- a/request_params.go
+++ b/request_params.go
@@ -1,21 +1,43 @@
 package jac
 
 import (
-	"time"
+	"net/http"
 )
 
 // RequestParams is a structure for performing different requests
 type RequestParams struct {
-	method      string
-	Endpoint    string
-	Body        []byte
-	Destination any
-	Query       map[string]string
-	Header      map[string]string
-	Timeout     time.Duration
+	method   string
+	Endpoint string
+	Body     []byte
+	Query    map[string]string
+	Header   map[string]string
 }
 
 func (rp RequestParams) addMethod(method string) RequestParams {
 	rp.method = method
 	return rp
+}
+
+func (rp RequestParams) addRequestQuery(r *http.Request) *http.Request {
+	if rp.Query != nil {
+		q := r.URL.Query()
+
+		for key, value := range rp.Query {
+			q.Add(key, value)
+		}
+
+		r.URL.RawQuery = q.Encode()
+	}
+
+	return r
+}
+
+func (rp RequestParams) addRequestHeaders(r *http.Request) *http.Request {
+	if rp.Header != nil {
+		for key, value := range rp.Header {
+			r.Header.Set(key, value)
+		}
+	}
+
+	return r
 }


### PR DESCRIPTION
# Problem

`resolveEndpoint` joined query parameters directly to the path parameters by encoding `?` to `%3F`, because of it services can't recognize query parameters from URL path.

# Solution

Refactor flow for performing requests making it more configurable